### PR TITLE
Disables the spot instance options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -664,29 +664,30 @@ resource "aws_elastic_beanstalk_environment" "default" {
     resource  = ""
   }
 
-  setting {
-    namespace = "aws:ec2:instances"
-    name      = "EnableSpot"
-    value     = var.enable_spot_instances ? "true" : "false"
-  }
-
-  setting {
-    namespace = "aws:ec2:instances"
-    name      = "SpotFleetOnDemandBase"
-    value     = var.spot_fleet_on_demand_base
-  }
-
-  setting {
-    namespace = "aws:ec2:instances"
-    name      = "SpotFleetOnDemandAboveBasePercentage"
-    value     = var.spot_fleet_on_demand_above_base_percentage == -1 ? (var.environment_type == "LoadBalanced" ? 70 : 0) : var.spot_fleet_on_demand_above_base_percentage
-  }
-
-  setting {
-    namespace = "aws:ec2:instances"
-    name      = "SpotMaxPrice"
-    value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
-  }
+# DISABLED: Not used in our current implemenation and causes erroneus changes during plan/apply
+#  setting {
+#    namespace = "aws:ec2:instances"
+#    name      = "EnableSpot"
+#    value     = var.enable_spot_instances ? "true" : "false"
+#  }
+#
+#  setting {
+#    namespace = "aws:ec2:instances"
+#    name      = "SpotFleetOnDemandBase"
+#    value     = var.spot_fleet_on_demand_base
+#  }
+#
+#  setting {
+#    namespace = "aws:ec2:instances"
+#    name      = "SpotFleetOnDemandAboveBasePercentage"
+#    value     = var.spot_fleet_on_demand_above_base_percentage == -1 ? (var.environment_type == "LoadBalanced" ? 70 : 0) : var.spot_fleet_on_demand_above_base_percentage
+#  }
+#
+#  setting {
+#    namespace = "aws:ec2:instances"
+#    name      = "SpotMaxPrice"
+#    value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
+#  }
 
   setting {
     namespace = "aws:autoscaling:launchconfiguration"


### PR DESCRIPTION
Disables the spot instance settings, as they are not needed and cause unnecessary changes for every plan/apply.

